### PR TITLE
Os 11 part 1 integrate django with auth0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ jobs:
           -v ${PWD}:/code
           opensorcery/npm-package-json-lint
     - stage: docker-compose up --build
+      before_script:
+        - ./scripts/create_env_file_for_docker_build.sh
       os: linux
       script: docker-compose up -d --build
       # - docker-compose run python manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ jobs:
           docker run --rm
           -v ${PWD}:/code
           opensorcery/npm-package-json-lint
+        - bash -c 'shopt -s globstar; shellcheck **/*.sh'
     - stage: docker-compose up --build
       before_script:
         - ./scripts/create_env_file_for_docker_build.sh

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ Automation here is a first class citizen, and we have a strong belief that all m
         `docker-compose` binary with `Make`, all the user needs to know is 
         `make up` serves them their development environment.
 
+#### scripts/ directory
+The scripts directory contains various helper scripts used at various stages of our pipelines or otherwise, these are similar in use to that of the `makefile` however they should be written into the `scripts directory` when they may be needed remotely. For example:
+        
+        scripts/create_env_file_for_docker_build.sh
+
+        Is used by `travis` to generate a file required for `docker-compose` to be tested effectively.
+
+Scripts should be written in line with `shellcheck` linting standards, and have documentation written for them.
+
 #### Make Commands
 
 Commands can be read by users by reading the [Makefile](https://github.com/opensorcery-io/opensorcery/blob/master/Makefile), otherwise, view the table below for a brief summary.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     command: python3 opensorcery/manage.py runserver 0.0.0.0:8000
     depends_on:
       - db
+    env_file:
+      - .env
     volumes:
       - .:/code
     ports:

--- a/opensorcery/opensorcery/settings.py
+++ b/opensorcery/opensorcery/settings.py
@@ -12,6 +12,11 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 
 import os
 
+import json
+from six.moves.urllib import request
+from cryptography.x509 import load_pem_x509_certificate
+from cryptography.hazmat.backends import default_backend
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -38,6 +43,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'opensorcery',
+    'rest_framework',
+    'rest_framework_jwt'
 ]
 
 MIDDLEWARE = [
@@ -103,6 +110,14 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
+    ),
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.0/topics/i18n/
@@ -122,3 +137,28 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 
 STATIC_URL = '/static/'
+
+AUTH0_DOMAIN = '<YOUR_AUTH0_DOMAIN>'
+API_IDENTIFIER = '<YOUR_API_IDENTIFIER>'
+PUBLIC_KEY = None
+JWT_ISSUER = None
+
+if AUTH0_DOMAIN:
+    jsonurl = request.urlopen('https://' + AUTH0_DOMAIN + '/.well-known/jwks.json')
+    jwks = json.loads(jsonurl.read().decode('utf-8'))
+    cert = '-----BEGIN CERTIFICATE-----\n' + jwks['keys'][0]['x5c'][0] + '\n-----END CERTIFICATE-----'
+    certificate = load_pem_x509_certificate(cert.encode('utf-8'), default_backend())
+    PUBLIC_KEY = certificate.public_key()
+    JWT_ISSUER = 'https://' + AUTH0_DOMAIN + '/'
+
+def jwt_get_username_from_payload_handler(payload):
+    return 'auth0user'
+
+JWT_AUTH = {
+    'JWT_PAYLOAD_GET_USERNAME_HANDLER': jwt_get_username_from_payload_handler,
+    'JWT_PUBLIC_KEY': PUBLIC_KEY,
+    'JWT_ALGORITHM': 'RS256',
+    'JWT_AUDIENCE': API_IDENTIFIER,
+    'JWT_ISSUER': JWT_ISSUER,
+    'JWT_AUTH_HEADER_PREFIX': 'Bearer',
+}

--- a/opensorcery/opensorcery/settings.py
+++ b/opensorcery/opensorcery/settings.py
@@ -138,8 +138,8 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-AUTH0_DOMAIN = '<YOUR_AUTH0_DOMAIN>'
-API_IDENTIFIER = '<YOUR_API_IDENTIFIER>'
+AUTH0_DOMAIN = os.getenv('auth0_domain')
+API_IDENTIFIER = os.getenv('api_identifier')
 PUBLIC_KEY = None
 JWT_ISSUER = None
 

--- a/opensorcery/opensorcery/urls.py
+++ b/opensorcery/opensorcery/urls.py
@@ -15,11 +15,15 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from django.conf.urls import url
 
+from user import views as user_views
 from . import views
 
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', views.index, name='index')
+    path('', views.index, name='index'),
+    url(r'^api/public/', user_views.public),
+    url(r'^api/private/', user_views.private)
 ]

--- a/opensorcery/user/views.py
+++ b/opensorcery/user/views.py
@@ -1,3 +1,11 @@
-from django.shortcuts import render
+from rest_framework.decorators import api_view
+from django.http import HttpResponse
 
-# Create your views here.
+
+def public(request):
+    return HttpResponse("You don't need to be authenticated to see this")
+
+
+@api_view(['GET'])
+def private(request):
+    return HttpResponse("You should not see this message if not authenticated!")

--- a/opensorcery/user/views.py
+++ b/opensorcery/user/views.py
@@ -8,4 +8,4 @@ def public(request):
 
 @api_view(['GET'])
 def private(request):
-    return HttpResponse("You should not see this message if not authenticated!")
+    return HttpResponse("You arenot authenticated!")

--- a/scripts/create_env_file_for_docker_build.sh
+++ b/scripts/create_env_file_for_docker_build.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Automation script used as a workaround for testing `docker-compose build`
+# within the `travis` pipeline. From the local environment, users have a `.env`
+# file present for the `docker-compose` build to ingest and supply the docker
+# containers/django application with the required secrets. However, we can't
+# log this via git, as this file contains secrets. So we dynamically generate it
+# using the `before_script` travis directive, and source the environmental
+# variables from the travis admin keychain.
 touch .env
 echo "auth0_domain=${auth0_domain}" >> .env
 echo "api_identifier=${api_identifier}" >> .env

--- a/scripts/create_env_file_for_docker_build.sh
+++ b/scripts/create_env_file_for_docker_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+touch .env
+echo "auth0_domain=${auth0_domain}" >> .env
+echo "api_identifier=${api_identifier}" >> .env

--- a/scripts/create_env_file_for_docker_build.sh
+++ b/scripts/create_env_file_for_docker_build.sh
@@ -7,5 +7,9 @@
 # using the `before_script` travis directive, and source the environmental
 # variables from the travis admin keychain.
 touch .env
+# We ignore both errors here because the script merely generates a file, we are
+# not using the bash, SC is idenitifying the vars as valid bash, not strings.
+# shellcheck disable=SC2154
 echo "auth0_domain=${auth0_domain}" >> .env
+# shellcheck disable=SC2154
 echo "api_identifier=${api_identifier}" >> .env


### PR DESCRIPTION
Part one of os11 implemented. This PR solves basic functionality and the introduction of the original auth0 code (with a minor variation to solve problems surrounding bandit linting directives) along with a minor addition to docker-compose and sourcing our first set of envvars required. A shell script is also being added to support the new env_file directive in docker-compose within the travis run.