### PR TITLE
UPDATE dc.yml - node_modules was sourcing from local, burnt local

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,5 +23,6 @@ services:
     command: npm run dev
     volumes:
       - ./frontend:/code
+      - /code/node_modules
     ports:
       - "8080:8080"


### PR DESCRIPTION
So it turns out that the #37 issue was a problem caused by my local `node_modules` dir being pulled in, numerous attempts at replication of the issue caused erroneous output because the local node_modules dir was overwriting the docker built node_modules dir. Cheers to @Samseppiol for reporting this bug. 