### PR TITLE
Include django tests within travis ci and clean the CI process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,12 +49,10 @@ jobs:
       os: linux
       script:
         - docker-compose up -d --build
-        - docker-compose --version
-        - docker --version
         - docker-compose images
         - docker-compose ps
         - docker-compose logs
-        # - docker-compose exec frontend npm list
+        - docker-compose exec backend python manage.py migrate
         - docker-compose exec backend python manage.py test
 
 # after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
     - stage: build docker-compose and run tests
       before_script:
         - ./scripts/create_env_file_for_docker_build.sh
+        - ./scripts/create_env_file_for_frontend_directory.sh
       os: linux
       script:
         - docker-compose up -d --build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,19 @@
 services:
   - docker
 
+env:
+  - DOCKER_COMPOSE_VERSION=1.23.2
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose  # yamllint disable-line
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"  # yamllint disable-line
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+
 jobs:
   include:
     - stage: code linting
@@ -29,12 +42,19 @@ jobs:
           -v ${PWD}:/code
           opensorcery/npm-package-json-lint
         - bash -c 'shopt -s globstar; shellcheck **/*.sh'
-    - stage: docker-compose up --build
+    - stage: build docker-compose and run tests
       before_script:
         - ./scripts/create_env_file_for_docker_build.sh
       os: linux
-      script: docker-compose up -d --build
-      # - docker-compose run python manage.py test
+      script:
+        - docker-compose up -d --build
+        - docker-compose --version
+        - docker --version
+        - docker-compose images
+        - docker-compose ps
+        - docker-compose logs
+        # - docker-compose exec frontend npm list
+        - docker-compose exec backend python manage.py test
 
 # after_success:
 # - coveralls

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The project uses Docker/Docker Compose to handle development environments. The setup is fairly simple:
 1. `git clone` the repository
 2. Ensure you have all the requirements installed with `make check_host_system_installs`.
-3. Create a `.env` file from the `.env.template` file in the root directory, place a copy in `frontend/`
+3. Create a `.env` file from the `.env.template` file in the root directory, place a copy in `frontend/` - Alternatively, use the `scripts/create_env_file_for_frontend_directory.sh` script to create it from locally sourced environmental variables.
 4. From the root of the directory, run `make django_migrate`
 5. From the root of the directory, run `make up`
 6. Navigate to `localhost:8000` for Django.

--- a/opensorcery/opensorcery/settings.py
+++ b/opensorcery/opensorcery/settings.py
@@ -155,8 +155,6 @@ PUBLIC_KEY = None
 JWT_ISSUER = None
 URL_SCHEME = "https"
 
-print(os.getenv('test_secret'))
-
 if AUTH0_DOMAIN != "":
     if URL_SCHEME == "https":
         # Bandit nosec rationalisation:

--- a/opensorcery/opensorcery/settings.py
+++ b/opensorcery/opensorcery/settings.py
@@ -143,11 +143,21 @@ STATIC_URL = '/static/'
 
 AUTH0_DOMAIN = os.getenv('auth0_domain')
 API_IDENTIFIER = os.getenv('api_identifier')
+
+environmental_variables = [AUTH0_DOMAIN, API_IDENTIFIER]
+for variable in environmental_variables:
+    if variable is not None:
+        pass
+    else:
+        raise ValueError("Neither auth0_domain or api_identifier can be empty")
+
 PUBLIC_KEY = None
 JWT_ISSUER = None
 URL_SCHEME = "https"
 
-if AUTH0_DOMAIN:
+print(os.getenv('test_secret'))
+
+if AUTH0_DOMAIN != "":
     if URL_SCHEME == "https":
         # Bandit nosec rationalisation:
         # We perform input validation here to ensure that only the `https` url scheme is used
@@ -162,6 +172,8 @@ if AUTH0_DOMAIN:
     certificate = load_pem_x509_certificate(cert.encode('utf-8'), default_backend())
     PUBLIC_KEY = certificate.public_key()
     JWT_ISSUER = 'https://' + AUTH0_DOMAIN + '/'
+else:
+    raise ValueError("AUTH0_DOMAIN environmental variable can not be empty.")
 
 def jwt_get_username_from_payload_handler(payload):
     return 'auth0user'

--- a/scripts/create_env_file_for_docker_build.sh
+++ b/scripts/create_env_file_for_docker_build.sh
@@ -10,6 +10,14 @@ touch .env
 # We ignore both errors here because the script merely generates a file, we are
 # not using the bash, SC is idenitifying the vars as valid bash, not strings.
 # shellcheck disable=SC2154
-echo "auth0_domain=${auth0_domain}" >> .env
+# echo "auth0_domain=${auth0_domain}" >> .env
 # shellcheck disable=SC2154
-echo "api_identifier=${api_identifier}" >> .env
+# echo "api_identifier=${api_identifier}" >> .env
+# shellcheck disable=SC2154
+# echo "test_secret=${test_secret}" >> .env
+
+{
+  echo "auth0_domain=${auth0_domain}"
+  echo "api_identifier=${api_identifier}"
+  echo "test_secret=${test_secret}"
+} >> .env

--- a/scripts/create_env_file_for_frontend_directory.sh
+++ b/scripts/create_env_file_for_frontend_directory.sh
@@ -12,9 +12,9 @@
 
 {
   # shellcheck disable=SC2154
-  echo "auth0_domain=${auth0_domain}"
+  echo "api_url=${api_url}"
   # shellcheck disable=SC2154
-  echo "api_identifier=${api_identifier}"
+  echo "client_id=${client_id}"
   # shellcheck disable=SC2154
-  echo "test_secret=${test_secret}"
-} >> .env
+  echo "frontend_redirect_url=${frontend_redirect_url}"
+} >> frontend/.env


### PR DESCRIPTION
So I recognised that the CI process was slightly flimsy recently and decided to do something about it, in particular, tests weren't running within the pipeline, which is borderline unforgivable for a CI, this, I recognised, was influencing my opinions around writing tests, because I didn't want to write tests because they weren't running, breaks in the build recently spurred me to decide to finally fix the problem. This then ran me into another issue, where the docker builds that were present in the pipeline were returning 0 exit codes, but the container itself was actually broken. It turns out this was a simple problem, I hand't included valid secrets in the Travis CI keychain, and instead of checking this first, I overengineered for 2 days before checking it. Overall, I have come out with a stronger pipeline though, one that we can pin docker and docker-compose on, and fixed a few other latent issues. This PR does not merge frontend tests, because they require Java in the build, which I haven't gotten to, this will be solved in the next, separate PR.